### PR TITLE
fix: inline `has-ansi`

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -2,13 +2,15 @@
 
 const isObject                     = require("type/object/is")
     , formatParts                  = require("sprintf-kit/format-parts")
-    , hasAnsi                      = require("has-ansi")
+    , ansiRegex                    = require("ansi-regex")({ onlyFirst: true })
     , { blackBright, red, yellow } = require("cli-color/bare")
     , LogWriter                    = require("log/lib/abstract-writer")
     , colorsSupportLevel           = require("./private/colors-support-level")
     , levelPrefixes                = require("./level-prefixes")
     , getNamespacePrefix           = require("./get-namespace-prefix")
     , resolveParts                 = require("./resolve-format-parts");
+
+const hasAnsi = string => ansiRegex.test(string);
 
 const WARNING_LEVEL_INDEX = 1, ERROR_LEVEL_INDEX = 0;
 

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
 		"url": "https://github.com/medikoo/log-node.git"
 	},
 	"dependencies": {
+		"ansi-regex": "^5.0.1",
 		"cli-color": "^2.0.0",
 		"cli-sprintf-format": "^1.1.0",
 		"d": "^1.0.1",
 		"es5-ext": "^0.10.53",
-		"has-ansi": "^4.0.1",
 		"sprintf-kit": "^2.0.1",
 		"supports-color": "^8.1.1",
 		"type": "^2.5.0"


### PR DESCRIPTION
This inlines `has-ansi` so that a secure version of `ansi-regex` is being used, since [it's looking very unlikely that any more backporting will occur](https://github.com/chalk/ansi-regex/issues/38).

This should filter downstream to [`serverless` ](https://github.com/chalk/ansi-regex/issues/38#issuecomment-948175167) (though I've got no idea what I'll do for `tabtab` 😞)

Fixes #5